### PR TITLE
add queue control commands and improve stop and auto-disconnect behavior

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -49,9 +49,7 @@ def pop_queue():
         
 
 def after_song(ctx, error=None):
-    if not show_queue():
-        autoDisconnect.start()
-        return
+    autoDisconnect.start()
     coro = play(ctx, url=None)
     future = asyncio.run_coroutine_threadsafe(coro, ctx.bot.loop)
     try:

--- a/bot.py
+++ b/bot.py
@@ -124,9 +124,9 @@ async def stop(ctx):
 @bot.command()
 async def sq(ctx):
     if not show_queue():
-        await ctx.send(" The queue is empty. Add some songs to keep the party going!")
+        await ctx.send("🚫 The queue is empty. Add some songs to keep the party going!")
         return
-    await ctx.send(f" The queue:\n{show_queue()}")
+    await ctx.send(f"📃 The queue:\n{show_queue()}")
 
 @tasks.loop(seconds=60)
 async def autoDisconnect():


### PR DESCRIPTION
Added !skip command to skip the currently playing song.
Added !jump <position> command to jump directly to a specific song in the queue.
Added !remove <position> command to remove a song from a specific position.
Added !clear command to remove all songs from the queue.
Added !top <position> command to take a song and get up to first queue.

Additional Enhancements:
Improved !stop behavior: the command now fully stops playback and prevents moving to the next song in the queue.

Updated auto-disconnect logic:
Bot now disconnects after 200 seconds of inactivity.
Timeout only starts when the queue is fully empty and nothing is playing.

These improvements ensure better control over playback flow and cleaner voice channel management.