### PR TITLE
Support search queries in addition to YouTube URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ Plays music from YouTube, manages queue, and auto-disconnects when idle.
 
 All commands must be used with `/` in any text channel where the bot is active.
 
-### 🎵 `/play <url>`
-Play a song from a YouTube URL or search term.
-- If a song is already playing, the song is added to the queue.
-- If not, it plays immediately.
+### 🎵 `/play <query>`
+Play a song from a YouTube URL or a search term.
+- If `<query>` is a YouTube URL, it plays the specified song.
+- If `<query>` is a search term (e.g., song name or artist), it searches YouTube and plays the top result.
+- If a song is already playing, the new song or search result is added to the queue.
+- If no song is playing, it plays immediately.
 
 ### ⏸️ `/pause`
 Pause the currently playing song.


### PR DESCRIPTION
- Changed the `/play` command parameter from URL-only to a generic `query`
- Added logic to detect if the input is a URL or a search term
- If input is a search term, perform a YouTube search and play the top result
- If input is a URL, play the exact YouTube video
- Maintain existing behavior of queueing songs if a song is already playing
- Updated command description and help messages to reflect new functionality